### PR TITLE
Remove mac check that fails with some recent Xen hypervisors

### DIFF
--- a/src/vnm/nic-xen.rb
+++ b/src/vnm/nic-xen.rb
@@ -61,10 +61,8 @@ module VNMNetwork
                     iface_id  = n[0]
                     iface_mac = n[2]
 
-                    if iface_mac == self[:mac]
-                        self[:tap] = "vif#{domid}.#{iface_id}"
-                        break
-                    end
+                    self[:tap] = "vif#{domid}.#{iface_id}"
+                    break
                 end
             end
             self


### PR DESCRIPTION
Hi,

"xl network-list" is now returning a null mac address with recent Ubuntu 14.04 updates.
Therefore, I had to remove the mac address check from nic-xen.rb

Best regards,

Laurent